### PR TITLE
fix(ui): compile with CFLAGS="-O0" to bypass jitterentropy optimizati…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ endef
 define Build/Compile/smartdns-ui
 	cargo install --force --locked bindgen-cli
 	CARGO_BUILD_ARGS="$(if $(strip $(RUST_PKG_FEATURES)),--features "$(strip $(RUST_PKG_FEATURES))") --profile $(CARGO_PKG_PROFILE)"
-	+$(CARGO_PKG_VARS) CARGO_BUILD_ARGS="$(CARGO_BUILD_ARGS)" CC=$(TARGET_CC) \
+	+$(CARGO_PKG_VARS) CARGO_BUILD_ARGS="$(CARGO_BUILD_ARGS)" CC=$(TARGET_CC) CFLAGS="-O0" \
 	PATH="$$(PATH):$(CARGO_HOME)/bin" \
 	make -C $(PKG_BUILD_DIR)/plugin/smartdns-ui
 endef


### PR DESCRIPTION
…on check

 to solve https://github.com/pymumu/smartdns/issues/2147, which also happened when compile with Openwrt 24.10 and SNAPSHOT SDK.