### PR TITLE
fix(smartdns): add missing zlib dependency for OpenWrt 25.12.4 snapshot builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endef
 define Package/smartdns
   $(Package/smartdns/default)
   TITLE:=smartdns server
-  DEPENDS:=+libpthread +libopenssl +libatomic
+  DEPENDS:=+libpthread +libopenssl +libatomic +zlib
 endef
 
 define Package/smartdns/description


### PR DESCRIPTION
Fix build failure on OpenWrt 25.12.4 snapshot caused by missing zlib dependency.

When building SmartDNS on OpenWrt 25.12.4 snapshot, package generation fails with:

Package smartdns is missing dependencies for the following libraries:
libz.so.1

Add the missing zlib dependency to ensure libz.so.1 is correctly resolved during APK package generation.